### PR TITLE
Tracknet train

### DIFF
--- a/ariadne/lightning.py
+++ b/ariadne/lightning.py
@@ -37,7 +37,7 @@ class TrainModel(pl.LightningModule):
 
     def _forward_batch(self, batch):
         x, y = batch
-        y_pred = self.model(**x)
+        y_pred = self.model(x)
         loss = self.criterion(y_pred, y)
         metric_vals = self._calc_metrics(y_pred, y)
         return {'loss': loss, **metric_vals}
@@ -53,7 +53,6 @@ class TrainModel(pl.LightningModule):
         result_dict = self._forward_batch(batch)
         tqdm_dict = {f'val_{k}': v for k, v in result_dict.items()}
         result = pl.EvalResult(checkpoint_on=result_dict['loss'])
-        print(result)
         result.log_dict(tqdm_dict, prog_bar=True)
         return result
 

--- a/ariadne/lightning.py
+++ b/ariadne/lightning.py
@@ -26,6 +26,7 @@ class TrainModel(pl.LightningModule):
         # Arguments
             inputs (dict): kwargs dict with model inputs
         """
+        #print(inputs)
         return self.model(**inputs)
 
     def _calc_metrics(self, batch_output, batch_target):
@@ -36,7 +37,7 @@ class TrainModel(pl.LightningModule):
 
     def _forward_batch(self, batch):
         x, y = batch
-        y_pred = self.model(x)
+        y_pred = self.model(**x)
         loss = self.criterion(y_pred, y)
         metric_vals = self._calc_metrics(y_pred, y)
         return {'loss': loss, **metric_vals}
@@ -52,6 +53,7 @@ class TrainModel(pl.LightningModule):
         result_dict = self._forward_batch(batch)
         tqdm_dict = {f'val_{k}': v for k, v in result_dict.items()}
         result = pl.EvalResult(checkpoint_on=result_dict['loss'])
+        print(result)
         result.log_dict(tqdm_dict, prog_bar=True)
         return result
 

--- a/ariadne/tracknet_v2/__init__.py
+++ b/ariadne/tracknet_v2/__init__.py
@@ -4,3 +4,4 @@ from . import model
 from . import dataset
 from . import processor
 from . import explicit_processor
+from . import data_loader

--- a/ariadne/tracknet_v2/data_loader.py
+++ b/ariadne/tracknet_v2/data_loader.py
@@ -1,0 +1,35 @@
+from collections import Callable
+
+import gin
+from torch.utils.data import DataLoader, Dataset, random_split, Subset
+
+from ariadne.data_loader import BaseDataLoader
+from ariadne.tracknet_v2.dataset import TrackNetV2Dataset
+
+
+@gin.configurable
+class TrackNetV2DataLoader(BaseDataLoader):
+
+    def __init__(self,
+                 batch_size: int,
+                 dataset: TrackNetV2Dataset.__class__,
+                 n_train: int,
+                 n_valid: int,
+                 with_random=True):
+        super(TrackNetV2DataLoader, self).__init__(batch_size)
+        self.dataset = dataset(n_samples=n_valid + n_train)
+        if with_random:
+            self.train_data, self.val_data = random_split(self.dataset, [n_train, n_valid])
+        else:
+            self.train_data = Subset(self.dataset, range(0, n_train)),
+            self.val_data = Subset(self.dataset, range(n_train, n_train + n_valid))
+
+    def get_val_dataloader(self) -> DataLoader:
+        return DataLoader(
+            dataset=self.val_data,
+            batch_size=self.batch_size)
+
+    def get_train_dataloader(self) -> DataLoader:
+        return DataLoader(
+            dataset=self.train_data,
+            batch_size=self.batch_size)

--- a/ariadne/tracknet_v2/data_loader.py
+++ b/ariadne/tracknet_v2/data_loader.py
@@ -1,7 +1,9 @@
 from collections import Callable
 
 import gin
+import torch
 from torch.utils.data import DataLoader, Dataset, random_split, Subset
+import numpy as np
 
 from ariadne.data_loader import BaseDataLoader
 from ariadne.tracknet_v2.dataset import TrackNetV2Dataset
@@ -13,11 +15,14 @@ class TrackNetV2DataLoader(BaseDataLoader):
     def __init__(self,
                  batch_size: int,
                  dataset: TrackNetV2Dataset.__class__,
-                 n_train: int,
-                 n_valid: int,
+                 max_size: int,
+                 n_valid: float,
                  with_random=True):
         super(TrackNetV2DataLoader, self).__init__(batch_size)
-        self.dataset = dataset(n_samples=n_valid + n_train)
+        self.dataset = dataset(n_samples=max_size)
+        data_size = len(self.dataset)
+        n_valid = int(data_size * n_valid)
+        n_train = data_size - n_valid
         if with_random:
             self.train_data, self.val_data = random_split(self.dataset, [n_train, n_valid])
         else:
@@ -27,9 +32,40 @@ class TrackNetV2DataLoader(BaseDataLoader):
     def get_val_dataloader(self) -> DataLoader:
         return DataLoader(
             dataset=self.val_data,
-            batch_size=self.batch_size)
+            batch_size=self.batch_size,
+            collate_fn=collate_fn)
 
     def get_train_dataloader(self) -> DataLoader:
         return DataLoader(
             dataset=self.train_data,
-            batch_size=self.batch_size)
+            batch_size=self.batch_size,
+            collate_fn=collate_fn)
+
+def collate_fn(samples):
+    """
+    """
+    #print(samples)
+    batch_size = len(samples)
+    # Special handling of batch size 1
+    # Get the matrix sizes in this batch
+    from collections import defaultdict
+    res = defaultdict(list)
+    {res[key].append(sub[key]) for sub in samples for key in sub}
+    #print(res)
+    samples = res
+    inputs = samples['inputs']
+    y = samples['y']
+    input_lengths = samples['input_lengths']
+    max_len = max(input_lengths)
+    n_features = samples['inputs'][0].shape[-1]
+    n_features_y = samples['y'][0].shape[-1]
+    # Allocate the tensors for this batch
+    batch_inputs = np.zeros((batch_size, max_len, n_features), dtype=np.float32)
+    batch_y = np.zeros((batch_size, n_features_y), dtype=np.float32)
+    # Loop over samples and fill the tensors
+    for i, g in enumerate(samples['input_lengths']):
+        batch_inputs[i, :input_lengths[i]] = inputs[i]
+        batch_y[i] = y[i]
+    batch_inputs = [torch.from_numpy(batch_inputs), torch.from_numpy(np.array(input_lengths))]
+    batch_target = torch.from_numpy(batch_y)
+    return batch_inputs, batch_target

--- a/ariadne/tracknet_v2/dataset.py
+++ b/ariadne/tracknet_v2/dataset.py
@@ -51,14 +51,31 @@ class PreprocessingBESDataset(Dataset):
 class TrackNetV2Dataset(Dataset):
     """TrackNET_v2 dataset."""
 
-    def __init__(self, data_file, use_index=False, n_samples=None):
+    def __init__(self, input_dir, use_index=False, n_samples=None):
         """
         Args:
             csv_file (string): Path to the csv file with data.
             preprocessing (callable, optional): Optional transform to be applied
                 on a dataframe.
         """
-        self.all_data = np.load(data_file)
+        self.input_dir = os.path.expandvars(input_dir)
+        filenames = [os.path.join(self.input_dir, f) for f in os.listdir(self.input_dir) if f.endswith('.npz')]
+        self.filenames = (filenames[:n_samples] if n_samples is not None else filenames)
+        d = {}
+        self.all_data = {}
+        for i, s in enumerate(self.filenames):
+            with np.load(s) as data:
+                if i == 0:
+                    for k in data.files:
+                        d[k] = []
+                # Loop over all the keys
+                for k in data.files:
+                    d[k].append(data[k])
+            # Merge arrays via np.vstack()
+        for k, v in d.items():
+            vv = np.concatenate(v, axis=0)
+            self.all_data[k] = vv
+
         self.use_index = use_index
         self.data = dict()
         if n_samples is not None:
@@ -77,14 +94,14 @@ class TrackNetV2Dataset(Dataset):
         if torch.is_tensor(idx):
             idx = idx.tolist()
         #print(self.data.keys())
-        sample_inputs = torch.tensor(self.data['inputs'][idx], dtype=torch.float)
-        sample_len = torch.tensor(self.data['input_lengths'][idx], dtype=torch.double)
-        sample_y = torch.tensor(self.data['y'][idx][:2], dtype=torch.float)
+        sample_inputs = self.data['inputs'][idx]
+        sample_len = self.data['input_lengths'][idx]
+        sample_y = self.data['y'][idx][:2]
         sample_idx = idx
         if self.use_index:
-            return {'inputs': sample_inputs, 'input_lengths': sample_len}, sample_y, sample_idx
+            return {'inputs': sample_inputs, 'input_lengths': sample_len, 'y': sample_y}, sample_idx
         else:
-            return {'inputs': sample_inputs, 'input_lengths': sample_len}, sample_y
+            return {'inputs': sample_inputs, 'input_lengths': sample_len, 'y': sample_y}
 
 class TrackNetV2ExplicitDataset(Dataset):
     """TrackNET_v2 dataset."""

--- a/ariadne/tracknet_v2/metrics.py
+++ b/ariadne/tracknet_v2/metrics.py
@@ -46,6 +46,26 @@ def point_in_ellipse(preds, target):
     left_side = x_part + y_part
     return left_side <= 1
 
+@gin.configurable(whitelist=[])
+def efficiency(preds, target):
+    """Checks if the next point of track segment
+    is located in the predicted circle
+    1 - if yes, 0 - otherwise
+    """
+    if preds.size(0) != target.size(0):
+        raise ValueError('Shape mismatch! Number of samples in '
+                        'the prediction and target must be equal. '
+                        f'{preds.size(0) != target.size(0)}')
+
+    if preds.size(1) != 4:
+        raise ValueError('Prediction must be 4-dimensional (x, y, r1, r2), '
+                            f'but got preds.shape[1] = {preds.size(1)}')
+
+    if target.size(1) != 2:
+        raise ValueError('Target must be 2-dimensional (x, y), '
+                             f'but got target.shape[1] = {target.size(1)}')
+    idx = point_in_ellipse(preds, target)
+    return torch.sum(idx) / len(idx)
 
 @gin.configurable(whitelist=[])
 def calc_metrics(inputs, model, tracklen=None):

--- a/ariadne/tracknet_v2/model.py
+++ b/ariadne/tracknet_v2/model.py
@@ -49,8 +49,9 @@ class TrackNETv2(nn.Module):
             nn.Softplus()
         )
 
-    def forward(self, inputs, input_lengths):
+    def forward(self, all_inputs):
         # BxTxC -> BxCxT
+        inputs, input_lengths = all_inputs
         inputs = inputs.transpose(1, 2)
         x = self.conv(inputs)
         # BxCxT -> BxTxC

--- a/ariadne/tracknet_v2/model.py
+++ b/ariadne/tracknet_v2/model.py
@@ -65,4 +65,4 @@ class TrackNETv2(nn.Module):
         # get result using only the output on the last timestep
         xy_coords = self.xy_coords(x[:, -1])
         r1_r2 = self.r1_r2(x[:, -1])
-        return torch.cat([xy_coords, r1_r2], dim=1)
+        return torch.squeeze(torch.cat([xy_coords, r1_r2], dim=1), dim=1)

--- a/ariadne/transformations.py
+++ b/ariadne/transformations.py
@@ -302,6 +302,7 @@ class ConstraintsNormalize(BaseTransformer):
         self.margin = margin
         self.use_global_constraints = use_global_constraints
         self.constraints = constraints
+        print(self.constraints)
         if constraints is not None:
             if use_global_constraints:
                 for col in columns:
@@ -341,6 +342,7 @@ class ConstraintsNormalize(BaseTransformer):
                         self.constraints.keys()]), 'Some station keys in constraints are not presented in data. Keys: ' \
                                                    '%r; data keys: %r' % (data['station'].unique(),
                                                                           self.constraints.keys())
+
             for station in self.constraints.keys():
                 group = data.loc[data['station'] == station,]
                 x_norm, y_norm, z_norm = self.normalize(group, self.constraints[station])

--- a/resources/gin/tracknet_v2_prepare.cfg
+++ b/resources/gin/tracknet_v2_prepare.cfg
@@ -1,24 +1,25 @@
 preprocess.target_processor = @ariadne.tracknet_v2.processor.TrackNet_Processor
-preprocess.output_dir = 'output/cgem_t_plain'
+preprocess.output_dir = 'output/cgem_t_tracknet'
 preprocess.ignore_asserts = False
 
-parse.input_file='resources/test_data/data_with_moment.txt'
+parse.input_file_mask='data/new_data/3.txt'
 parse.csv_params={
                     "sep": '\s+',
-                    "nrows": 1000,
+                    #"nrows": 1000,
                     "encoding": 'utf-8',
-                    "names": ['event','x','y','z','station','track','px','py','pz','vx','vy','vz']
+                    "names":  ['event',  'x', 'y', 'z', 'station',
+                               'track', 'px', 'py', 'pz', 'X0', 'Y0', 'Z0']
                  }
 
 ### events_quantity:
 # ['1..10'] (list of events with these indexes)
 # or [':'] (all events from df)
 # or single index ['3']
-parse.events_quantity = '1..10'
+parse.events_quantity = '1..300'
 ariadne.tracknet_v2.processor.TrackNet_Processor.name_suffix = 'all'
 ariadne.tracknet_v2.processor.TrackNet_Processor.radial_stations_constraints = {
-    0: {'r': [-167., 167.], 'phi': [-3.14, 3.14], 'z': [-423.5, 423.5]},
-    1: {'r': [-167., 167.], 'phi': [-3.14, 3.14], 'z': [-423.5, 423.5]},
-    2: {'r': [-167., 167.], 'phi': [-3.14, 3.14], 'z': [-423.5, 423.5]},
+    0: {'r': [-167., 167.], 'phi': [-3.15, 3.15], 'z': [-423.5, 423.5]},
+    1: {'r': [-167., 167.], 'phi': [-3.15, 3.15], 'z': [-423.5, 423.5]},
+    2: {'r': [-167., 167.], 'phi': [-3.15, 3.15], 'z': [-423.5, 423.5]},
 }
 

--- a/resources/gin/tracknet_v2_prepare.cfg
+++ b/resources/gin/tracknet_v2_prepare.cfg
@@ -2,7 +2,7 @@ preprocess.target_processor = @ariadne.tracknet_v2.processor.TrackNet_Processor
 preprocess.output_dir = 'output/cgem_t_tracknet'
 preprocess.ignore_asserts = False
 
-parse.input_file_mask='data/new_data/3.txt'
+parse.input_file_mask='data/new_data/2.txt'
 parse.csv_params={
                     "sep": '\s+',
                     #"nrows": 1000,
@@ -15,8 +15,8 @@ parse.csv_params={
 # ['1..10'] (list of events with these indexes)
 # or [':'] (all events from df)
 # or single index ['3']
-parse.events_quantity = '1..300'
-ariadne.tracknet_v2.processor.TrackNet_Processor.name_suffix = 'all'
+parse.events_quantity = '1..100'
+ariadne.tracknet_v2.processor.TrackNet_Processor.name_suffix = 'all_2'
 ariadne.tracknet_v2.processor.TrackNet_Processor.radial_stations_constraints = {
     0: {'r': [-167., 167.], 'phi': [-3.15, 3.15], 'z': [-423.5, 423.5]},
     1: {'r': [-167., 167.], 'phi': [-3.15, 3.15], 'z': [-423.5, 423.5]},

--- a/resources/gin/tracknet_v2_train.cfg
+++ b/resources/gin/tracknet_v2_train.cfg
@@ -1,7 +1,7 @@
 ### experiment setup ###
 experiment.model = @TrackNETv2
 experiment.criterion = @TrackNetLoss
-experiment.metrics = [@ellipse_area, @point_in_ellipse]
+experiment.metrics = [@ellipse_area, @efficiency]
 experiment.optimizer = @Adam
 experiment.data_loader = @TrackNetV2DataLoader
 experiment.epochs = 150
@@ -17,11 +17,12 @@ TrackNETv2.batch_first = True
 ### data ###
 TrackNetV2DataLoader.batch_size = 16
 TrackNetV2DataLoader.dataset = @TrackNetV2Dataset
-TrackNetV2DataLoader.n_train = 871
-TrackNetV2DataLoader.n_valid = 350
+TrackNetV2DataLoader.max_size = 871
+TrackNetV2DataLoader.n_valid = 0.3
+
 
 # dataset
-TrackNetV2Dataset.data_file = 'output/cgem_t_tracknet/tracknet_all.npz'
+TrackNetV2Dataset.input_dir = 'output/cgem_t_tracknet'
 
 ### loss ###
 TrackNetLoss.alpha = 0.9

--- a/resources/gin/tracknet_v2_train.cfg
+++ b/resources/gin/tracknet_v2_train.cfg
@@ -3,13 +3,25 @@ experiment.model = @TrackNETv2
 experiment.criterion = @TrackNetLoss
 experiment.metrics = [@ellipse_area, @point_in_ellipse]
 experiment.optimizer = @Adam
+experiment.data_loader = @TrackNetV2DataLoader
+experiment.epochs = 150
+experiment.fp16_training = False
 experiment.random_seed = 42
 
 ### model ###
-TrackNETv2.input_features = 4
+TrackNETv2.input_features = 3
 TrackNETv2.conv_features = 32
 TrackNETv2.rnn_type = 'gru'
 TrackNETv2.batch_first = True
+
+### data ###
+TrackNetV2DataLoader.batch_size = 16
+TrackNetV2DataLoader.dataset = @TrackNetV2Dataset
+TrackNetV2DataLoader.n_train = 871
+TrackNetV2DataLoader.n_valid = 350
+
+# dataset
+TrackNetV2Dataset.data_file = 'output/cgem_t_tracknet/tracknet_all.npz'
 
 ### loss ###
 TrackNetLoss.alpha = 0.9


### PR DESCRIPTION
Added:
1) TrackNet_V2 training, 
2) multiple data files handling for TrackNet dataset, 
3) proper efficiency metric calculation
4) data_loader for TrackNet with sequence padding. It means, if batch contains different input lengths, short sequences are filled with zeros
5) Slightly changed model input: it waits for list or tuple of inputs and input_lengths and unpacks it inside. This was made to provide one input of GraphNet and TrackNet in _forward_batch of lightning.py. Previously, with dictionaries, an error was raised in this method